### PR TITLE
Update `rustls-connector` to `0.21`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "tcp-stream"
-version       = "0.29.0"
+version       = "0.28.0"
 authors       = ["Marc-Antoine Perennou <Marc-Antoine@Perennou.com>"]
 edition       = "2021"
 description   = "std::net::TcpStream on steroids"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "tcp-stream"
-version       = "0.28.0"
+version       = "0.29.0"
 authors       = ["Marc-Antoine Perennou <Marc-Antoine@Perennou.com>"]
 edition       = "2021"
 description   = "std::net::TcpStream on steroids"
@@ -15,13 +15,17 @@ rust-version  = "1.63.0"
 name = "tcp_stream"
 
 [features]
-default                   = ["rustls"]
+default                   = ["rustls--aws_lc_rs"]
 native-tls                = ["dep:native-tls", "rustls-pemfile"]
-rustls                    = ["rustls-native-certs"]
 rustls-webpki-roots-certs = ["rustls-common", "rustls-connector/webpki-roots-certs"]
 rustls-native-certs       = ["rustls-common", "rustls-connector/native-certs"]
 rustls-common             = ["rustls-connector", "rustls-pemfile", "p12-keystore"]
 vendored-openssl          = ["openssl/vendored"]
+
+# rustls crypto providers. Choose at least one. Otherwise, runtime errors.
+# See https://docs.rs/rustls/latest/rustls/#crate-features. for more info
+rustls--aws_lc_rs         = ["rustls-native-certs", "rustls-connector/rustls--aws_lc_rs"] # default, but doesn't build everywhere
+rustls--ring              = ["rustls-native-certs", "rustls-connector/rustls--ring"] # more compatible, (e.g., easily builds on Windows)
 
 [dependencies]
 cfg-if = "^1.0"
@@ -43,7 +47,7 @@ version = "^2.0"
 optional = true
 
 [dependencies.rustls-connector]
-version          = "^0.20"
+version          = "^0.21"
 optional         = true
 default-features = false
 


### PR DESCRIPTION
Change the feature `rustls` to `rustls--ring` or `rustls--aws_lc_rs`.

However, there is a MSRV issue:

![image](https://github.com/amqp-rs/tcp-stream/assets/56253288/21049241-82f2-4866-ad21-8dd4ba8c163e)