### PR TITLE
Remove Pemfile dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,15 +1819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,7 +2106,6 @@ dependencies = [
  "openssl",
  "p12-keystore",
  "rustls-connector",
- "rustls-pemfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ native-tls-futures        = ["dep:async-native-tls", "futures", "native-tls"]
 openssl-futures           = ["dep:async-openssl", "futures", "openssl"]
 rustls-futures            = ["futures", "rustls", "rustls-connector/futures"]
 
-native-tls                = ["dep:native-tls", "dep:rustls-pemfile"]
+native-tls                = ["dep:native-tls"]
 openssl                   = ["dep:openssl"]
 rustls-webpki-roots-certs = ["rustls", "rustls-connector/webpki-roots-certs"]
 rustls-native-certs       = ["rustls", "rustls-connector/native-certs"]
-rustls                    = ["dep:rustls-connector", "dep:rustls-pemfile", "dep:p12-keystore"]
+rustls                    = ["dep:rustls-connector", "dep:p12-keystore"]
 vendored-openssl          = ["openssl", "openssl/vendored"]
 
 # rustls crypto providers. Choose at least one. Otherwise, runtime errors.
@@ -70,10 +70,6 @@ optional = true
 
 [dependencies.p12-keystore]
 version = "^0.2"
-optional = true
-
-[dependencies.rustls-pemfile]
-version = "^2.0"
 optional = true
 
 [dependencies.rustls-connector]

--- a/src/native_tls_impl.rs
+++ b/src/native_tls_impl.rs
@@ -3,6 +3,8 @@ use crate::{
     TcpStream,
 };
 
+use rustls_connector::rustls_pki_types::{CertificateDer, pem::PemObject};
+
 #[cfg(feature = "native-tls-futures")]
 use {
     crate::AsyncTcpStream,
@@ -44,8 +46,9 @@ fn native_tls_connector_builder(
     }
     if let Some(cert_chain) = config.cert_chain {
         let mut cert_chain = std::io::BufReader::new(cert_chain.as_bytes());
-        for cert in
-            CertificateDer::pem_reader_iter(&mut cert_chain).collect::<Result<Vec<_>, _>>()?
+        for cert in CertificateDer::pem_reader_iter(&mut cert_chain)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
         {
             builder
                 .add_root_certificate(Certificate::from_der(&cert[..]).map_err(io::Error::other)?);

--- a/src/native_tls_impl.rs
+++ b/src/native_tls_impl.rs
@@ -44,7 +44,9 @@ fn native_tls_connector_builder(
     }
     if let Some(cert_chain) = config.cert_chain {
         let mut cert_chain = std::io::BufReader::new(cert_chain.as_bytes());
-        for cert in rustls_pemfile::certs(&mut cert_chain).collect::<Result<Vec<_>, _>>()? {
+        for cert in
+            CertificateDer::pem_reader_iter(&mut cert_chain).collect::<Result<Vec<_>, _>>()?
+        {
             builder
                 .add_root_certificate(Certificate::from_der(&cert[..]).map_err(io::Error::other)?);
         }

--- a/src/rustls_impl.rs
+++ b/src/rustls_impl.rs
@@ -10,7 +10,7 @@ use {
 };
 
 use rustls_connector::rustls_pki_types::{
-    CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, pem::PemObject,
+    pem::PemObject, CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer,
 };
 use std::io;
 
@@ -36,7 +36,7 @@ fn update_rustls_config(
 ) -> io::Result<()> {
     if let Some(cert_chain) = config.cert_chain {
         let mut cert_chain = std::io::BufReader::new(cert_chain.as_bytes());
-        let certs = rustls_pemfile::certs(&mut cert_chain)
+        let certs = CertificateDer::pem_reader_iter(&mut cert_chain)
             .collect::<Result<Vec<_>, _>>()
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
         c.add_parsable_certificates(certs);
@@ -66,7 +66,7 @@ fn rustls_identity(
         }
         Identity::PKCS8 { pem, key } => {
             let mut cert_reader = std::io::BufReader::new(pem);
-            let certs = rustls_pemfile::certs(&mut cert_reader)
+            let certs = CertificateDer::pem_reader_iter(&mut cert_reader)
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
             (

--- a/src/rustls_impl.rs
+++ b/src/rustls_impl.rs
@@ -10,7 +10,7 @@ use {
 };
 
 use rustls_connector::rustls_pki_types::{
-    pem::PemObject, CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer,
+    CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, pem::PemObject,
 };
 use std::io;
 


### PR DESCRIPTION
## What this PR does

- We remove the [rustls-pemfile](https://github.com/rustls/pemfile) dependency
- Instead we use the already imported [rustls-pki-types](https://crates.io/crates/rustls-pki-types)

## Context

The [rustls-pemfile](https://github.com/rustls/pemfile) crate has been archived. There is a [hint](https://github.com/rustls/pemfile?tab=readme-ov-file#see-also-rustls-pki-types) that the main function of that crate has been incorporated into [rustls-pki-types](https://crates.io/crates/rustls-pki-types).


## Questions
I ran `cargo test` but it only ran 1 test. Please let me know if this is enough what other testing I should do.
