### PR TITLE
Fix typo in RustlsConnectorConfig function call

### DIFF
--- a/src/futures.rs
+++ b/src/futures.rs
@@ -111,7 +111,7 @@ async fn into_tls_impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
         } else if #[cfg(all(feature = "rustls-futures", feature = "rustls-native-certs"))] {
             crate::into_rustls_impl_async(s, RustlsConnectorConfig::new_with_native_certs()?, domain, config).await
         } else if #[cfg(all(feature = "rustls-futures", feature = "rustls-webpki-roots-certs"))] {
-            crate::into_rustls_impl_async(s, RustlsConnectorConfig::new_with_webpki_roots_certs(), domain, config).await
+            crate::into_rustls_impl_async(s, RustlsConnectorConfig::new_with_webpki_root_certs(), domain, config).await
         } else if #[cfg(feature = "rustls-futures")] {
             crate::into_rustls_impl_async(s, RustlsConnectorConfig::default(), domain, config).await
         } else if #[cfg(feature = "openssl-futures")] {


### PR DESCRIPTION
Hello,

Looking at current lib code https://github.com/amqp-rs/rustls-connector/blob/main/src/lib.rs#L73

Also, features might not be tested during release, as the latest version was able to pass CI and get released.
Might I create another issue to track this ?

Thanks !